### PR TITLE
fix: avoid colliding IPs in retry-after jitter test

### DIFF
--- a/spec/unit/features/decision_api.feature
+++ b/spec/unit/features/decision_api.feature
@@ -138,7 +138,7 @@ Feature: Decision API unit behavior
       Given the decision api dependencies are initialized
       And the mode is "decision_service"
       And the rule engine decision is reject with reason "rate_limit_exceeded" and retry_after 10
-      When I run the access handler for clients "10.0.0.1" and "10.0.0.2"
+      When I run the access handler for clients "10.0.0.1" and "10.0.1.1"
       Then retry after headers are different
       And the test cleanup restores globals
 


### PR DESCRIPTION
## Summary
- replace the second client IP in the flaky Retry-After jitter unit scenario
- use a non-colliding subnet so deterministic jitter seeds differ across clients

## Testing
- busted spec/unit/decision_api_spec.lua

Closes #7